### PR TITLE
Add base path

### DIFF
--- a/examples/configs/config-dev.json
+++ b/examples/configs/config-dev.json
@@ -15,7 +15,8 @@
 			"verticleInstances": 8,
 			"catServerHost": "",
 			"catServerPort": 1,
-			"port": 1
+			"port": 1,
+			"basePath" : ""
 		},
 		{
 			"id": "iudx.rs.proxy.authenticator.AuthenticationVerticle",

--- a/examples/configs/config-test.json
+++ b/examples/configs/config-test.json
@@ -15,7 +15,8 @@
       "verticleInstances": 8,
       "catServerHost": "",
       "catServerPort": 1,
-      "port": 1
+      "port": 1,
+      "basePath": ""
     },
     {
       "id": "iudx.rs.proxy.authenticator.AuthenticationVerticle",

--- a/examples/consumers(adapter)/data_txt.json
+++ b/examples/consumers(adapter)/data_txt.json
@@ -1,0 +1,1 @@
+{"id":["iisc.ac.in/89a36273d77dac4cf38114fca1bbe64392547f86/rs.iudx.io/pune-env-flood/FWR055"],"time":"2020-10-18T14:20:00Z","endtime":"2020-10-19T14:20:00Z","timerel":"during","options":"count","searchType":"temporalSearch_","instanceID":"localhost:8090","applicableFilters":["ATTR","TEMPORAL"],"publicKey":"1uxmO5GqpqootKRxK_6f_HvJ7ownd_ejwd_kZBN-bzM="}

--- a/examples/consumers(adapter)/rabbitmq.py
+++ b/examples/consumers(adapter)/rabbitmq.py
@@ -42,57 +42,72 @@ def on_message_received(ch, method, properties, body):
 
     str_b_public_key = props_dict['headers']['publicKey']
     print("encoded public key : ", str_b_public_key)
+    if str_b_public_key is None or str_b_public_key.isspace():
+        print("Public key is null or empty")
+        requestJson = json.loads(body)
+        requestId = requestJson['searchType'];
+        dictionary = {'adapter': 'pune-aqm', 'correlation_id': properties.correlation_id, 'reply_to_queue': properties.reply_to,
+                      'id': 'requestId', 'response': requestJson}
+        jsonString = json.dumps(dictionary, indent=4)
+        reply_queue = properties.reply_to
+        print(" [INFO] Publishing query response")
+        ch.basic_publish(exchange='',
+                         routing_key=reply_queue,
+                         properties=pika.BasicProperties(correlation_id=properties.correlation_id),
+                         body=str(jsonString))
+        ch.basic_ack(delivery_tag=method.delivery_tag)
+        print(method.delivery_tag)
+    else:
+        b64_b_public_key = base64.urlsafe_b64decode(str_b_public_key)
 
-    b64_b_public_key = base64.urlsafe_b64decode(str_b_public_key)
+        # convert the bytes to object type
 
-    # convert the bytes to object type
+        public_key = PublicKey(b64_b_public_key)
 
-    public_key = PublicKey(b64_b_public_key)
+        # Create a SealedBox object
 
-    # Create a SealedBox object
+        sealed_box = SealedBox(public_key)
 
-    sealed_box = SealedBox(public_key)
+        # Load the JSON data to a python variable
 
-    # Load the JSON data to a python variable
+        with open('data_txt.json') as f:
+            message = json.load(f)
 
-    with open('data_txt.json') as f:
-        message = json.load(f)
+        message_bytes = json.dumps(message).encode()
 
-    message_bytes = json.dumps(message).encode()
+        encrypted = sealed_box.encrypt(message_bytes)
 
-    encrypted = sealed_box.encrypt(message_bytes)
+        # encrypted is of type bytes and it is not JSON Serializable
+        # We convert it to string and send it
 
-    # encrypted is of type bytes and it is not JSON Serializable
-    # We convert it to string and send it
+        b64_encrypted = base64.urlsafe_b64encode(encrypted)
 
-    b64_encrypted = base64.urlsafe_b64encode(encrypted)
+        str_encrypted = b64_encrypted.decode("utf-8")
 
-    str_encrypted = b64_encrypted.decode("utf-8")
-
-    sample_dataset = {
-        "results":[
-            {
-                "encrypted_data": [str_encrypted]
-            }
-        ]
-    }
-    requestJson = json.loads(body)
-    requestId = requestJson['searchType'];
-    dictionary = {'adapter':'pune-aqm','correlation_id':properties.correlation_id, 'reply_to_queue':properties.reply_to, 'id':requestId,'response':requestJson,'results': {'encryptedData':str_encrypted}}
-    jsonString = json.dumps(dictionary, indent=4)
+        sample_dataset = {
+            "results":[
+                {
+                    "encrypted_data": [str_encrypted]
+                }
+            ]
+        }
+        requestJson = json.loads(body)
+        requestId = requestJson['searchType'];
+        dictionary = {'adapter':'pune-aqm','correlation_id':properties.correlation_id, 'reply_to_queue':properties.reply_to, 'id':requestId,'response':requestJson,'results': {'encryptedData':str_encrypted}}
+        jsonString = json.dumps(dictionary, indent=4)
 
 
-    print("\n[INFO] Publishing query response to ")
+        print("\n[INFO] Publishing query response to ")
 
-    reply_queue = props_dict['reply_to']
-    print(reply_queue)
+        reply_queue = props_dict['reply_to']
+        print(reply_queue)
 
-    # publish the encrypted data to the reply queue
-    ch.basic_publish(exchange='',
-                     routing_key=reply_queue,
-                     properties=pika.BasicProperties(correlation_id=properties.correlation_id),
-                     body=str(jsonString))
-    ch.basic_ack(delivery_tag=method.delivery_tag)
+        # publish the encrypted data to the reply queue
+        ch.basic_publish(exchange='',
+                         routing_key=reply_queue,
+                         properties=pika.BasicProperties(correlation_id=properties.correlation_id),
+                         body=str(jsonString))
+        ch.basic_ack(delivery_tag=method.delivery_tag)
 
 
 

--- a/examples/consumers(adapter)/rabbitmq.py
+++ b/examples/consumers(adapter)/rabbitmq.py
@@ -1,0 +1,105 @@
+import pika
+import ssl
+import json
+import base64
+from nacl.public import SealedBox, PublicKey
+
+
+username = ''
+password = ''
+host = 'databroker.iudx.io'
+port = 24567
+vhost = 'IUDX-INTERNAL'
+context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+
+ssl_options=pika.SSLOptions(context)
+credentials = pika.PlainCredentials(username,password)
+
+
+
+connection = pika.BlockingConnection(
+    pika.URLParameters(f'amqps://{username}:{password}@{host}:{port}/{vhost}'))
+# cp)
+
+channel = connection.channel()
+
+print("[INFO] Connecting to RabbitMQ: Credentials Verifies :) ")
+
+def on_message_received(ch, method, properties, body):
+
+    print("\n [INFO] Received new message")
+
+    # Get the JSON message from the body
+
+    json_data = open(r"data_txt.json", "w")
+    json_data.write(body.decode())
+    json_data.close()
+    # convert properties to dictionary format
+
+    props_dict = properties.__dict__
+    print("properties : ",properties)
+    # Get the public key from the properties
+
+    str_b_public_key = props_dict['headers']['publicKey']
+    print("encoded public key : ", str_b_public_key)
+
+    b64_b_public_key = base64.urlsafe_b64decode(str_b_public_key)
+
+    # convert the bytes to object type
+
+    public_key = PublicKey(b64_b_public_key)
+
+    # Create a SealedBox object
+
+    sealed_box = SealedBox(public_key)
+
+    # Load the JSON data to a python variable
+
+    with open('data_txt.json') as f:
+        message = json.load(f)
+
+    message_bytes = json.dumps(message).encode()
+
+    encrypted = sealed_box.encrypt(message_bytes)
+
+    # encrypted is of type bytes and it is not JSON Serializable
+    # We convert it to string and send it
+
+    b64_encrypted = base64.urlsafe_b64encode(encrypted)
+
+    str_encrypted = b64_encrypted.decode("utf-8")
+
+    sample_dataset = {
+        "results":[
+            {
+                "encrypted_data": [str_encrypted]
+            }
+        ]
+    }
+    requestJson = json.loads(body)
+    requestId = requestJson['searchType'];
+    dictionary = {'adapter':'pune-aqm','correlation_id':properties.correlation_id, 'reply_to_queue':properties.reply_to, 'id':requestId,'response':requestJson,'results': {'encryptedData':str_encrypted}}
+    jsonString = json.dumps(dictionary, indent=4)
+
+
+    print("\n[INFO] Publishing query response to ")
+
+    reply_queue = props_dict['reply_to']
+    print(reply_queue)
+
+    # publish the encrypted data to the reply queue
+    ch.basic_publish(exchange='',
+                     routing_key=reply_queue,
+                     properties=pika.BasicProperties(correlation_id=properties.correlation_id),
+                     body=str(jsonString))
+    ch.basic_ack(delivery_tag=method.delivery_tag)
+
+
+
+channel.basic_qos(prefetch_count=1)
+channel.basic_consume(queue='rpc_pune-aqm', auto_ack=False,
+                      on_message_callback=on_message_received)
+
+
+print(" [x] Awaiting RPC requests")
+channel.start_consuming()

--- a/src/main/java/iudx/rs/proxy/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/rs/proxy/apiserver/ApiServerVerticle.java
@@ -80,7 +80,7 @@ public class ApiServerVerticle extends AbstractVerticle {
   private DatabaseService databaseService;
   private MeteringService meteringService;
   private DatabrokerService brokerService;
-
+  private String basePath;
   @Override
   public void start() throws Exception {
     catalogueService = new CatalogueService(vertx, config());
@@ -88,6 +88,7 @@ public class ApiServerVerticle extends AbstractVerticle {
     meteringService = MeteringService.createProxy(vertx, METERING_SERVICE_ADDRESS);
     brokerService = DatabrokerService.createProxy(vertx, DATABROKER_SERVICE_ADDRESS);
     validator = new ParamsValidator(catalogueService);
+    basePath = config().getString("basePath");
     router = Router.router(vertx);
     router.route().handler(
         CorsHandler.create("*").allowedHeaders(ALLOWED_HEADERS).allowedMethods(ALLOWED_METHODS))
@@ -156,20 +157,20 @@ public class ApiServerVerticle extends AbstractVerticle {
     FailureHandler validationsFailureHandler = new FailureHandler();
 
     ValidationHandler entityValidationHandler = new ValidationHandler(vertx, RequestType.ENTITY);
-    router.get(NGSILD_ENTITIES_URL).handler(entityValidationHandler)
+    router.get(basePath + NGSILD_ENTITIES_URL).handler(entityValidationHandler)
         .handler(AuthHandler.create(vertx)).handler(this::handleEntitiesQuery)
         .failureHandler(validationsFailureHandler);
 
     ValidationHandler temporalValidationHandler =
         new ValidationHandler(vertx, RequestType.TEMPORAL);
 
-    router.get(NGSILD_TEMPORAL_URL).handler(temporalValidationHandler)
+    router.get(basePath + NGSILD_TEMPORAL_URL).handler(temporalValidationHandler)
         .handler(AuthHandler.create(vertx)).handler(this::handleTemporalQuery)
         .failureHandler(validationsFailureHandler);
 
-    router.get(IUDX_CONSUMER_AUDIT_URL).handler(AuthHandler.create(vertx))
+    router.get(basePath + IUDX_CONSUMER_AUDIT_URL).handler(AuthHandler.create(vertx))
         .handler(this::getConsumerAuditDetail);
-    router.get(IUDX_PROVIDER_AUDIT_URL).handler(AuthHandler.create(vertx))
+    router.get(basePath + IUDX_PROVIDER_AUDIT_URL).handler(AuthHandler.create(vertx))
         .handler(this::getProviderAuditDetail);
 
     router

--- a/src/main/java/iudx/rs/proxy/apiserver/ParamsValidator.java
+++ b/src/main/java/iudx/rs/proxy/apiserver/ParamsValidator.java
@@ -1,31 +1,5 @@
 package iudx.rs.proxy.apiserver;
 
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.HEADER_OPTIONS;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.HEADER_TOKEN;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.IUDXQUERY_OPTIONS;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.IUDX_SEARCH_TYPE;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.MSG_BAD_QUERY;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_ATTRIBUTE;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_COORDINATES;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_ENDTIME;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_ENTITIES;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_FROM;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_GEOMETRY;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_GEOPROPERTY;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_GEOQ;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_GEOREL;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_ID;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_IDPATTERN;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_OPERATOR;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_SIZE;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_TEMPORALQ;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_TIME;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_TIMEPROPERTY;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_TIMEREL;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_TIME_PROPERTY;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_TYPE;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSLILDQUERY_Q;
-
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
@@ -36,6 +10,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import static iudx.rs.proxy.apiserver.util.ApiServerConstants.*;
 
 /**
  * This class is used to validate NGSI-LD request and request parameters.
@@ -79,6 +55,8 @@ public class ParamsValidator {
     validHeaders.add(HEADER_TOKEN);
     validHeaders.add("User-Agent");
     validHeaders.add("Content-Type");
+    validHeaders.add(HEADER_PUBLIC_KEY);
+
   }
 
   private final CatalogueService catalogueService;

--- a/src/main/java/iudx/rs/proxy/apiserver/handlers/AuthHandler.java
+++ b/src/main/java/iudx/rs/proxy/apiserver/handlers/AuthHandler.java
@@ -42,9 +42,10 @@ public class AuthHandler implements Handler<RoutingContext> {
   static AuthenticationService authenticator;
   private final String AUTH_INFO = "authInfo";
   private HttpServerRequest request;
-
-  public static AuthHandler create(Vertx vertx) {
+  private static String basePath;
+  public static AuthHandler create(Vertx vertx, JsonObject config) {
     authenticator = AuthenticationService.createProxy(vertx, AUTH_SERVICE_ADDRESS);
+    basePath = config.getString("basePath");
     return new AuthHandler();
   }
 
@@ -155,14 +156,14 @@ public class AuthHandler implements Handler<RoutingContext> {
   private String getNormalizedPath(String url) {
     LOGGER.debug("URL : " + url);
     String path = null;
-    if (url.matches(TEMPORAL_URL_REGEX)) {
-      path = NGSILD_TEMPORAL_URL;
-    } else if (url.matches(ENTITIES_URL_REGEX)) {
-      path = NGSILD_ENTITIES_URL;
-    } else if (url.matches(IUDX_CONSUMER_AUDIT_URL)) {
-      path = IUDX_CONSUMER_AUDIT_URL;
-    } else if (url.matches(IUDX_PROVIDER_AUDIT_URL)) {
-      path = IUDX_PROVIDER_AUDIT_URL;
+    if (url.matches(basePath + TEMPORAL_URL_REGEX)) {
+      path = basePath + NGSILD_TEMPORAL_URL;
+    } else if (url.matches(basePath + ENTITIES_URL_REGEX)) {
+      path = basePath + NGSILD_ENTITIES_URL;
+    } else if (url.matches(basePath + IUDX_CONSUMER_AUDIT_URL)) {
+      path = basePath + IUDX_CONSUMER_AUDIT_URL;
+    } else if (url.matches(basePath + IUDX_PROVIDER_AUDIT_URL)) {
+      path = basePath + IUDX_PROVIDER_AUDIT_URL;
     }
     return path;
   }

--- a/src/main/java/iudx/rs/proxy/apiserver/handlers/ValidationHandler.java
+++ b/src/main/java/iudx/rs/proxy/apiserver/handlers/ValidationHandler.java
@@ -16,6 +16,8 @@ import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import static iudx.rs.proxy.apiserver.util.ApiServerConstants.HEADER_PUBLIC_KEY;
+
 public class ValidationHandler implements Handler<RoutingContext> {
 
 
@@ -35,6 +37,7 @@ public class ValidationHandler implements Handler<RoutingContext> {
     ValidatorsHandlersFactory validationFactory = new ValidatorsHandlersFactory();
     MultiMap parameters = context.request().params();
     Map<String, String> pathParams = context.pathParams();
+    parameters.set(HEADER_PUBLIC_KEY,context.request().getHeader(HEADER_PUBLIC_KEY));
     parameters.addAll(pathParams);
     
     List<Validator> validations = validationFactory.build(requestType, parameters);

--- a/src/main/java/iudx/rs/proxy/apiserver/util/ApiServerConstants.java
+++ b/src/main/java/iudx/rs/proxy/apiserver/util/ApiServerConstants.java
@@ -33,14 +33,14 @@ public class ApiServerConstants {
 
   //path regex
   public static final String NGSILD_BASE_PATH = "/ngsi-ld/v1";
-  public static final String NGSILD_ENTITIES_URL = NGSILD_BASE_PATH + "/entities";
+  public static final String NGSILD_ENTITIES_URL = "/entities";
   public static final String ENTITIES_URL_REGEX = NGSILD_ENTITIES_URL + "(.*)";
-  public static final String NGSILD_TEMPORAL_URL = NGSILD_BASE_PATH + "/temporal/entities";
+  public static final String NGSILD_TEMPORAL_URL ="/temporal/entities";
   // path regex
   public static final String TEMPORAL_URL_REGEX = NGSILD_TEMPORAL_URL + "(.*)";
-  public static final String IUDX_CONSUMER_AUDIT_URL = NGSILD_BASE_PATH + "/consumer/audit";
+  public static final String IUDX_CONSUMER_AUDIT_URL =  "/consumer/audit";
   // date-time format
-  public static final String IUDX_PROVIDER_AUDIT_URL = NGSILD_BASE_PATH + "/provider/audit";
+  public static final String IUDX_PROVIDER_AUDIT_URL =  "/provider/audit";
   public static final String API_ENDPOINT = "apiEndpoint";
   public static final String API_METHOD = "method";
   public static final String ID = "id";

--- a/src/main/java/iudx/rs/proxy/apiserver/util/ApiServerConstants.java
+++ b/src/main/java/iudx/rs/proxy/apiserver/util/ApiServerConstants.java
@@ -116,6 +116,8 @@ public class ApiServerConstants {
   public static final Pattern ID_REGEX =
       Pattern.compile(
           "^[a-zA-Z0-9.]{4,100}/{1}[a-zA-Z0-9.]{4,100}/{1}[a-zA-Z.]{4,100}/{1}[a-zA-Z-_.]{4,100}/{1}[a-zA-Z0-9-_.]{4,100}$");
+  public static final String ENCODED_PUBLIC_KEY_REGEX = "^[a-zA-Z0-9_-]{42,43}={0,2}$";
+
   public static final String RESPONSE_SIZE = "response_size";
 
   public static final double VALIDATION_ALLOWED_DIST = 1000.0;

--- a/src/main/java/iudx/rs/proxy/apiserver/util/ApiServerConstants.java
+++ b/src/main/java/iudx/rs/proxy/apiserver/util/ApiServerConstants.java
@@ -19,6 +19,8 @@ public class ApiServerConstants {
   public static final String HEADER_REFERER = "Referer";
   public static final String HEADER_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
   public static final String HEADER_OPTIONS = "options";
+  public static final String HEADER_PUBLIC_KEY = "publicKey";
+
 
   public static final Set<String> ALLOWED_HEADERS =
       new HashSet<>(Arrays.asList(HEADER_ACCEPT, HEADER_TOKEN, HEADER_CONTENT_LENGTH,

--- a/src/main/java/iudx/rs/proxy/apiserver/validation/ValidatorsHandlersFactory.java
+++ b/src/main/java/iudx/rs/proxy/apiserver/validation/ValidatorsHandlersFactory.java
@@ -1,41 +1,16 @@
 package iudx.rs.proxy.apiserver.validation;
 
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.IUDXQUERY_OPTIONS;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_ATTRIBUTE;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_COORDINATES;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_ENDTIME;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_FROM;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_GEOMETRY;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_GEOPROPERTY;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_GEOREL;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_ID;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_MAXDISTANCE;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_OPERATOR;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_SIZE;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_TIME;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSILDQUERY_TIMEREL;
-import static iudx.rs.proxy.apiserver.util.ApiServerConstants.NGSLILDQUERY_Q;
-
 import io.vertx.core.MultiMap;
 import iudx.rs.proxy.apiserver.util.RequestType;
-import iudx.rs.proxy.apiserver.validation.types.AttrsTypeValidator;
-import iudx.rs.proxy.apiserver.validation.types.CoordinatesTypeValidator;
-import iudx.rs.proxy.apiserver.validation.types.DateTypeValidator;
-import iudx.rs.proxy.apiserver.validation.types.DistanceTypeValidator;
-import iudx.rs.proxy.apiserver.validation.types.GeoPropertyTypeValidator;
-import iudx.rs.proxy.apiserver.validation.types.GeoRelTypeValidator;
-import iudx.rs.proxy.apiserver.validation.types.GeometryTypeValidator;
-import iudx.rs.proxy.apiserver.validation.types.IDTypeValidator;
-import iudx.rs.proxy.apiserver.validation.types.OptionsTypeValidator;
-import iudx.rs.proxy.apiserver.validation.types.PaginationLimitTypeValidator;
-import iudx.rs.proxy.apiserver.validation.types.PaginationOffsetTypeValidator;
-import iudx.rs.proxy.apiserver.validation.types.QTypeValidator;
-import iudx.rs.proxy.apiserver.validation.types.TimeRelTypeValidator;
-import iudx.rs.proxy.apiserver.validation.types.Validator;
+import iudx.rs.proxy.apiserver.validation.types.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import static iudx.rs.proxy.apiserver.util.ApiServerConstants.*;
+import static iudx.rs.proxy.apiserver.util.ApiServerConstants.HEADER_PUBLIC_KEY;
 
 public class ValidatorsHandlersFactory {
 
@@ -81,6 +56,9 @@ public class ValidatorsHandlersFactory {
     validators.add(new PaginationLimitTypeValidator(parameters.get(NGSILDQUERY_SIZE), false));
     validators.add(new PaginationOffsetTypeValidator(parameters.get(NGSILDQUERY_FROM), false));
 
+    //optional header public key
+    validators.add(new HeaderKeyTypeValidation(parameters.get(HEADER_PUBLIC_KEY),false));
+
     return validators;
 
   }
@@ -103,6 +81,9 @@ public class ValidatorsHandlersFactory {
     validators.add(new TimeRelTypeValidator(parameters.get(NGSILDQUERY_TIMEREL), true));
     validators.add(new DateTypeValidator(parameters.get(NGSILDQUERY_TIME), true));
     validators.add(new DateTypeValidator(parameters.get(NGSILDQUERY_ENDTIME), false));
+
+    //optional header public key
+    validators.add(new HeaderKeyTypeValidation(parameters.get(HEADER_PUBLIC_KEY),false));
 
     return validators;
   }

--- a/src/main/java/iudx/rs/proxy/apiserver/validation/types/HeaderKeyTypeValidation.java
+++ b/src/main/java/iudx/rs/proxy/apiserver/validation/types/HeaderKeyTypeValidation.java
@@ -1,0 +1,54 @@
+package iudx.rs.proxy.apiserver.validation.types;
+
+import iudx.rs.proxy.apiserver.exceptions.DxRuntimeException;
+import iudx.rs.proxy.apiserver.handlers.ValidationHandler;
+import iudx.rs.proxy.common.HttpStatusCode;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.regex.Pattern;
+
+import static iudx.rs.proxy.apiserver.util.ApiServerConstants.ENCODED_PUBLIC_KEY_REGEX;
+import static iudx.rs.proxy.common.ResponseUrn.INVALID_HEADER_VALUE_URN;
+
+public final class HeaderKeyTypeValidation implements Validator {
+    private static final Logger LOG = LogManager.getLogger(ValidationHandler.class);
+    private final String value;
+    private final boolean required;
+
+    public HeaderKeyTypeValidation(final String value, final boolean required) {
+        this.value = value;
+        this.required = required;
+    }
+
+    @Override
+    public boolean isValid() {
+        LOG.info("inside isValid");
+        if (required && (value == null || value.isEmpty())) {
+            LOG.error("Validation error : Public key is null or empty");
+            throw new DxRuntimeException(failureCode(), INVALID_HEADER_VALUE_URN, failureMessage());
+        } else if (!required && value == null) {
+            return true;
+        } else if (!required && value.isEmpty()) {
+            LOG.error("Validation error : The value of the public key is empty in the publicKey header");
+            throw new DxRuntimeException(failureCode(), INVALID_HEADER_VALUE_URN, failureMessage());
+        } else if (value.length() != 44) {
+            LOG.error("Validation error : Invalid Public Key length");
+            throw new DxRuntimeException(failureCode(), INVALID_HEADER_VALUE_URN, failureMessage());
+        } else if (!Pattern.matches(ENCODED_PUBLIC_KEY_REGEX, value)) {
+            LOG.error("Validation error : Public key contains invalid urlbase64 character");
+            throw new DxRuntimeException(failureCode(), INVALID_HEADER_VALUE_URN, failureMessage());
+        }
+        return true;
+    }
+
+    @Override
+    public int failureCode() {
+        return HttpStatusCode.BAD_REQUEST.getValue();
+    }
+
+    @Override
+    public String failureMessage() {
+        return INVALID_HEADER_VALUE_URN.getMessage();
+    }
+}

--- a/src/test/java/iudx/rs/proxy/apiserver/handlers/AuthHandlerTest.java
+++ b/src/test/java/iudx/rs/proxy/apiserver/handlers/AuthHandlerTest.java
@@ -76,7 +76,7 @@ class AuthHandlerTest {
     @Test
     public void testCreate(VertxTestContext vertxTestContext) {
         AuthHandler.authenticator = mock(AuthenticationService.class);
-        assertNotNull(AuthHandler.create(Vertx.vertx()));
+        assertNotNull(AuthHandler.create(Vertx.vertx(),jsonObject));
         vertxTestContext.completeNow();
     }
      @Test

--- a/src/test/java/iudx/rs/proxy/apiserver/validation/types/HeaderKeyTypeValidationTest.java
+++ b/src/test/java/iudx/rs/proxy/apiserver/validation/types/HeaderKeyTypeValidationTest.java
@@ -1,0 +1,66 @@
+package iudx.rs.proxy.apiserver.validation.types;
+
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import iudx.rs.proxy.apiserver.exceptions.DxRuntimeException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(VertxExtension.class)
+@ExtendWith(MockitoExtension.class)
+public class HeaderKeyTypeValidationTest {
+
+private static HeaderKeyTypeValidation validation;
+
+    public static Stream<Arguments> inputValues()
+    {
+        return Stream.of(
+        Arguments.of(null,false),
+        Arguments.of("I6W24wZTKcH0Xl6ykwD8eSLv8EZIhPa2WkwYzmZzP10=",true),
+        Arguments.of("nKU4Mdtq01N9BY_AAu5Hr_ha8IFuqWMfhWiBRBhb4lA=",true)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputValues")
+    @DisplayName("Test isValid method : Success")
+    public void testIsValid(String value, boolean required, VertxTestContext vertxTestContext)
+    {
+        validation = new HeaderKeyTypeValidation(value,required);
+        assertTrue(validation.isValid());
+        vertxTestContext.completeNow();
+    }
+
+    public static Stream<Arguments> invalidInputValues()
+    {
+        return Stream.of(
+                Arguments.of(null,true),
+                Arguments.of("",true),
+                Arguments.of("",false),
+                Arguments.of("some public key value",true),
+                Arguments.of("I6W24wZTKcH0Xl6ykwD8eSLv8EZIhPa2WkwYz+/++10",true)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidInputValues")
+    @DisplayName("Test isValid method : Failure")
+    public void testIsValidFailure(String value, boolean required, VertxTestContext vertxTestContext)
+    {
+        validation = new HeaderKeyTypeValidation(value,required);
+        assertThrows(DxRuntimeException.class,()-> validation.isValid());
+        vertxTestContext.completeNow();
+    }
+
+
+
+}


### PR DESCRIPTION
- Added `basePath` param in examples/configs/config-dev.json and examples/configs/config-test.json with default value as a blank string
- `basePath` param should be added in secrets/all-verticles-configs as and when necessary
- Changed the following classes : 
  - AuthHandler.java
  - ApiServerConstants.java
  - AuthHandlerTest.java
  - ApiServerVerticle.java
- Updated rabbitmq.py [here](https://github.com/datakaveri/iudx-rs-proxy/pull/20/commits/d35422b5c9792c969f0a509853e0dcbf20897006#diff-b5710570bdc6c68e5b347603d89496aad90fc46280c1c7dfb63b935527dc3718)