### PR TITLE
Make server items configurable

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -31,7 +31,9 @@ info:
     - **Base path**:
       - Base path is the path on which API is served, relative to the host
       - It is the initial part of the API
-      - The base path value could be configured according to the deployment
+      - These base path values could be configured according to the deployment
+      - The base path for [DX AAA Server](https://github.com/datakaveri/iudx-aaa-server) is set to `/auth/v1`
+      - The base path for [DX Catalogue Server](https://github.com/datakaveri/iudx-catalogue-server) is set to `/iudx/cat/v1`
           Currently, the following APIs have `/ngsi-ld/v1` base path
           -  /entities
           -  /temporal/entities

--- a/src/main/java/iudx/rs/proxy/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/rs/proxy/apiserver/ApiServerVerticle.java
@@ -87,7 +87,8 @@ public class ApiServerVerticle extends AbstractVerticle {
   private DatabaseService databaseService;
   private MeteringService meteringService;
   private DatabrokerService brokerService;
-  
+  private String dxCatalogueBasePath;
+  private String dxAuthBasePath;
   private String dxApiBasePath;
 
   @Override
@@ -97,8 +98,11 @@ public class ApiServerVerticle extends AbstractVerticle {
     meteringService = MeteringService.createProxy(vertx, METERING_SERVICE_ADDRESS);
     brokerService = DatabrokerService.createProxy(vertx, DATABROKER_SERVICE_ADDRESS);
     validator = new ParamsValidator(catalogueService);
-    
+
+    /* Get base paths from config */
     dxApiBasePath=config().getString("dxApiBasePath");
+    dxCatalogueBasePath = config().getString("dxCatalogueBasePath");
+    dxAuthBasePath = config().getString("dxAuthBasePath");
     Api apis=Api.getInstance(dxApiBasePath);
     
     router = Router.router(vertx);

--- a/src/main/java/iudx/rs/proxy/apiserver/service/CatalogueService.java
+++ b/src/main/java/iudx/rs/proxy/apiserver/service/CatalogueService.java
@@ -1,6 +1,8 @@
 package iudx.rs.proxy.apiserver.service;
 
 import static iudx.rs.proxy.apiserver.util.Util.toList;
+import static iudx.rs.proxy.authenticator.Constants.CAT_ITEM_PATH;
+import static iudx.rs.proxy.authenticator.Constants.CAT_SEARCH_PATH;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -36,8 +38,9 @@ public class CatalogueService {
   private long cacheTimerid;
   private static String catHost;
   private static int catPort;;
-  private static String catSearchPath;
-  private static String catItemPath;
+  private String catBasePath;
+  private String catItemPath;
+  private String catSearchPath;
   private Vertx vertx;
 
   private final Cache<String, List<String>> applicableFilterCache =
@@ -48,8 +51,9 @@ public class CatalogueService {
     this.vertx = vertx;
     catHost = config.getString("catServerHost");
     catPort = config.getInteger("catServerPort");
-    catSearchPath = Constants.CAT_RSG_PATH;
-    catItemPath = Constants.CAT_ITEM_PATH;
+    catBasePath = config.getString("dxCatalogueBasePath");
+    catItemPath = catBasePath + CAT_ITEM_PATH;
+    catSearchPath = catBasePath + CAT_SEARCH_PATH;
 
     WebClientOptions options =
         new WebClientOptions().setTrustAll(true).setVerifyHost(false).setSsl(true);
@@ -189,8 +193,8 @@ public class CatalogueService {
         });
         handler.handle(Future.succeededFuture(filters));
       } else if (catHandler.failed()) {
-        LOGGER.error("catalogue call(/iudx/cat/v1/item) failed for id" + id);
-        handler.handle(Future.failedFuture("catalogue call(/iudx/cat/v1/item) failed for id" + id));
+        LOGGER.error("catalogue call ("+ catItemPath + ") failed for id" + id);
+        handler.handle(Future.failedFuture("catalogue call(" + catItemPath + ") failed for id" + id));
       }
     });
   }

--- a/src/main/java/iudx/rs/proxy/authenticator/AuthenticationVerticle.java
+++ b/src/main/java/iudx/rs/proxy/authenticator/AuthenticationVerticle.java
@@ -1,5 +1,6 @@
 package iudx.rs.proxy.authenticator;
 
+import static iudx.rs.proxy.authenticator.Constants.AUTH_CERTIFICATE_PATH;
 import static iudx.rs.proxy.common.Constants.*;
 
 import io.vertx.core.AbstractVerticle;
@@ -117,8 +118,9 @@ public class AuthenticationVerticle extends AbstractVerticle {
   private Future<String> getJwtPublicKey(Vertx vertx, JsonObject config) {
     Promise<String> promise = Promise.promise();
     webClient = createWebClient(vertx, config);
+    String authCert = config.getString("dxAuthBasePath") + AUTH_CERTIFICATE_PATH;
     webClient
-        .get(443, config.getString("authServerHost"), "/auth/v1/cert")
+        .get(443, config.getString("authServerHost"), authCert)
         .send(
             handler -> {
               if (handler.succeeded()) {

--- a/src/main/java/iudx/rs/proxy/authenticator/Constants.java
+++ b/src/main/java/iudx/rs/proxy/authenticator/Constants.java
@@ -6,8 +6,9 @@ public class Constants {
 
   public static final List<String> OPEN_ENDPOINTS = List.of("/temporal/entities","/entities","/consumer/audit","/entityOperations/query");
   public static final long CACHE_TIMEOUT_AMOUNT = 30;
-  public static final String CAT_RSG_PATH = "/iudx/cat/v1/search";
-  public static final String CAT_ITEM_PATH = "/iudx/cat/v1/item";
+  public static final String CAT_SEARCH_PATH = "/search";
+  public static final String AUTH_CERTIFICATE_PATH = "/cert";
+  public static final String CAT_ITEM_PATH = "/item";
   public static final String JSON_USERID = "userid";
   public static final String JSON_IID = "iid";
   public static final String JSON_EXPIRY = "expiry";

--- a/src/main/java/iudx/rs/proxy/authenticator/Constants.java
+++ b/src/main/java/iudx/rs/proxy/authenticator/Constants.java
@@ -3,7 +3,8 @@ package iudx.rs.proxy.authenticator;
 import java.util.List;
 
 public class Constants {
-  public static final List<String> OPEN_ENDPOINTS = List.of("/ngsi-ld/v1/temporal/entities","/ngsi-ld/v1/entities","/ngsi-ld/v1/consumer/audit","/ngsi-ld/v1/entityOperations/query");
+
+  public static final List<String> OPEN_ENDPOINTS = List.of("/temporal/entities","/entities","/consumer/audit","/entityOperations/query");
   public static final long CACHE_TIMEOUT_AMOUNT = 30;
   public static final String CAT_RSG_PATH = "/iudx/cat/v1/search";
   public static final String CAT_ITEM_PATH = "/iudx/cat/v1/item";

--- a/src/main/java/iudx/rs/proxy/authenticator/JwtAuthenticationServiceImpl.java
+++ b/src/main/java/iudx/rs/proxy/authenticator/JwtAuthenticationServiceImpl.java
@@ -206,7 +206,7 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
     Promise<JsonObject> promise = Promise.promise();
     String jwtId = jwtData.getIid().split(":")[1];
 
-    if (openResource && OPEN_ENDPOINTS.contains(authInfo.getString("apiEndpoint"))) {
+    if (openResource && checkOpenEndPoints(authInfo.getString("apiEndpoint"))) {
       LOGGER.info("User access is allowed.");
       JsonObject jsonResponse = new JsonObject();
       jsonResponse.put(JSON_IID, jwtId);
@@ -240,6 +240,16 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
     return promise.future();
   }
 
+  private boolean checkOpenEndPoints(String endPoint) {
+    for(String item : OPEN_ENDPOINTS)
+    {
+      if(endPoint.contains(item))
+      {
+        return true;
+      }
+    }
+    return false;
+  }
   Future<Boolean> isValidAudienceValue(JwtData jwtData) {
     Promise<Boolean> promise = Promise.promise();
     if (audience != null && audience.equalsIgnoreCase(jwtData.getAud())) {

--- a/src/main/java/iudx/rs/proxy/authenticator/JwtAuthenticationServiceImpl.java
+++ b/src/main/java/iudx/rs/proxy/authenticator/JwtAuthenticationServiceImpl.java
@@ -1,10 +1,5 @@
 package iudx.rs.proxy.authenticator;
 
-import static iudx.rs.proxy.authenticator.Constants.JSON_EXPIRY;
-import static iudx.rs.proxy.authenticator.Constants.JSON_IID;
-import static iudx.rs.proxy.authenticator.Constants.JSON_USERID;
-import static iudx.rs.proxy.authenticator.Constants.OPEN_ENDPOINTS;
-
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import io.vertx.core.AsyncResult;
@@ -40,6 +35,8 @@ import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import static iudx.rs.proxy.authenticator.Constants.*;
+
 public class JwtAuthenticationServiceImpl implements AuthenticationService {
 
   private static final Logger LOGGER = LogManager.getLogger(JwtAuthenticationServiceImpl.class);
@@ -52,6 +49,7 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
   final CacheService cache;
   static WebClient catWebClient;
   final Api apis;
+  final String catBasePath;
   // resourceGroupCache will contain ACL info about all resource group in a resource server
   Cache<String, String> resourceGroupCache = CacheBuilder.newBuilder().maximumSize(1000)
       .expireAfterAccess(Constants.CACHE_TIMEOUT_AMOUNT, TimeUnit.MINUTES).build();
@@ -67,7 +65,8 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
     this.audience = config.getString("audience");
     this.host = config.getString("catServerHost");
     this.port = config.getInteger("catServerPort");
-    this.path = Constants.CAT_RSG_PATH;
+    this.catBasePath = config.getString("dxCatalogueBasePath");
+    this.path = catBasePath + CAT_SEARCH_PATH;
     this.apis=apis;
     WebClientOptions options = new WebClientOptions();
     options.setTrustAll(true).setVerifyHost(false).setSsl(true);

--- a/src/main/java/iudx/rs/proxy/metering/MeteringServiceImpl.java
+++ b/src/main/java/iudx/rs/proxy/metering/MeteringServiceImpl.java
@@ -7,6 +7,9 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.sqlclient.PoolOptions;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import iudx.rs.proxy.common.Api;
 import iudx.rs.proxy.common.Response;
 import iudx.rs.proxy.database.DatabaseService;
 import iudx.rs.proxy.databroker.DatabrokerService;
@@ -34,7 +37,7 @@ public class MeteringServiceImpl implements MeteringService {
   public final String _ID_COLUMN;
   private final Vertx vertx;
   private final QueryBuilder queryBuilder = new QueryBuilder();
-  private final ParamsValidation validation = new ParamsValidation();
+  private ParamsValidation validation;
   public static DatabrokerService rmqService;
   private final ObjectMapper objectMapper = new ObjectMapper();
   PgConnectOptions connectOptions;
@@ -53,7 +56,7 @@ public class MeteringServiceImpl implements MeteringService {
   public static DatabaseService postgresService;
   private ResponseBuilder responseBuilder;
 
-  public MeteringServiceImpl(JsonObject propObj, Vertx vertxInstance) {
+  public MeteringServiceImpl(JsonObject propObj, Vertx vertxInstance, Api api) {
 
     if (propObj != null && !propObj.isEmpty()) {
       databaseIP = propObj.getString(DATABASE_IP);
@@ -63,6 +66,7 @@ public class MeteringServiceImpl implements MeteringService {
       databasePassword = propObj.getString(DATABASE_PASSWORD);
       databaseTableName = propObj.getString(DATABASE_TABLE_NAME);
       databasePoolSize = propObj.getInteger(POOL_SIZE);
+      validation = new ParamsValidation(api);
     }
 
     this.connectOptions =

--- a/src/main/java/iudx/rs/proxy/metering/MeteringVerticle.java
+++ b/src/main/java/iudx/rs/proxy/metering/MeteringVerticle.java
@@ -13,6 +13,7 @@ import io.vertx.core.AbstractVerticle;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.ServiceBinder;
+import iudx.rs.proxy.common.Api;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -29,6 +30,7 @@ public class MeteringVerticle extends AbstractVerticle {
   private ServiceBinder binder;
   private MessageConsumer<JsonObject> consumer;
   private MeteringService metering;
+  private Api api;
 
   @Override
   public void start() throws Exception {
@@ -48,9 +50,10 @@ public class MeteringVerticle extends AbstractVerticle {
     propObj.put(DATABASE_USERNAME, databaseUserName);
     propObj.put(DATABASE_PASSWORD, databasePassword);
     propObj.put(POOL_SIZE, poolSize);
+    api = Api.getInstance(config().getString("dxApiBasePath"));
 
     binder = new ServiceBinder(vertx);
-    metering = new MeteringServiceImpl(propObj, vertx);
+    metering = new MeteringServiceImpl(propObj, vertx, api);
     consumer =
         binder.setAddress(METERING_SERVICE_ADDRESS).register(MeteringService.class, metering);
     LOGGER.info("Metering Verticle Started");

--- a/src/main/java/iudx/rs/proxy/metering/util/Constants.java
+++ b/src/main/java/iudx/rs/proxy/metering/util/Constants.java
@@ -10,8 +10,7 @@ public class Constants {
   public static final String TIME_RELATION = "timeRelation";
   public static final String DURING = "during";
   public static final String HEADER_OPTIONS = "options";
-  public static final String IUDX_ADAPTOR_URL = "/ngsi-ld/v1";
-  public static final String IUDX_PROVIDER_AUDIT_URL = IUDX_ADAPTOR_URL + "/provider/audit";
+
   public static final String ORIGIN = "origin";
   public static final String ORIGIN_SERVER = "rs-server";
   public static final String PRIMARY_KEY= "primaryKey";
@@ -19,6 +18,7 @@ public class Constants {
   public static final String ROUTING_KEY = "#";
   public static final String TOTAL = "total";
   public static final String TABLE_NAME = "tableName";
+
 
   /* configs */
   public static final String DATABASE_IP = "meteringDatabaseIP";

--- a/src/main/java/iudx/rs/proxy/metering/util/ParamsValidation.java
+++ b/src/main/java/iudx/rs/proxy/metering/util/ParamsValidation.java
@@ -1,6 +1,7 @@
 package iudx.rs.proxy.metering.util;
 
 import io.vertx.core.json.JsonObject;
+import iudx.rs.proxy.common.Api;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -11,14 +12,19 @@ import java.time.temporal.ChronoUnit;
 import static iudx.rs.proxy.metering.util.Constants.*;
 
 public class ParamsValidation {
+  private Api api;
 
+  public ParamsValidation(Api api)
+  {
+    this.api = api;
+  }
   private static final Logger LOGGER = LogManager.getLogger(ParamsValidation.class);
 
   public JsonObject paramsCheck(JsonObject request) {
     String providerID = request.getString(PROVIDER_ID);
     String iid = request.getString(IID);
 
-    if (request.getString(ENDPOINT).equals(IUDX_PROVIDER_AUDIT_URL)
+    if (request.getString(ENDPOINT).equals(api.getProviderAuditEndpoint())
         && request.getString(PROVIDER_ID) == null) {
       LOGGER.debug("Info: " + INVALID_PROVIDER_REQUIRED);
       return new JsonObject().put(ERROR, INVALID_PROVIDER_REQUIRED);

--- a/src/test/java/iudx/rs/proxy/authenticator/JwtAuthenticationServiceImplTest.java
+++ b/src/test/java/iudx/rs/proxy/authenticator/JwtAuthenticationServiceImplTest.java
@@ -88,6 +88,8 @@ class JwtAuthenticationServiceImplTest {
         authConfig.put("host", "rs.iudx.io");
         authConfig.put("catServerPort", 8080);
         authConfig.put("dxApiBasePath","/ngsi-ld/v1");
+        authConfig.put("dxCatalogueBasePath", "/iudx/cat/v1");
+        authConfig.put("dxAuthBasePath", "/auth/v1");
 
         JWTAuthOptions jwtAuthOptions = new JWTAuthOptions();
         jwtAuthOptions.addPubSecKey(

--- a/src/test/resources/IUDX-Resource-Proxy-Server-Consumer-APIs.postman_collection.json
+++ b/src/test/resources/IUDX-Resource-Proxy-Server-Consumer-APIs.postman_collection.json
@@ -46,14 +46,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -113,14 +112,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -191,7 +189,7 @@
 							}
 						},
 						"url": {
-							"raw": "https://authvertx.iudx.io/auth/v1/token",
+							"raw": "https://authvertx.iudx.io/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"authvertx",
@@ -199,8 +197,7 @@
 								"io"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -271,7 +268,7 @@
 							}
 						},
 						"url": {
-							"raw": "https://authvertx.iudx.io/auth/v1/token",
+							"raw": "https://authvertx.iudx.io/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"authvertx",
@@ -279,8 +276,7 @@
 								"io"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -351,7 +347,7 @@
 							}
 						},
 						"url": {
-							"raw": "https://authvertx.iudx.io/auth/v1/token",
+							"raw": "https://authvertx.iudx.io/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"authvertx",
@@ -359,8 +355,7 @@
 								"io"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -431,7 +426,7 @@
 							}
 						},
 						"url": {
-							"raw": "https://authvertx.iudx.io/auth/v1/token",
+							"raw": "https://authvertx.iudx.io/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"authvertx",
@@ -439,8 +434,7 @@
 								"io"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}

--- a/src/test/resources/IUDX-Resource-Proxy-Server-Consumer-APIs.postman_environment.postman_environment.json
+++ b/src/test/resources/IUDX-Resource-Proxy-Server-Consumer-APIs.postman_environment.postman_environment.json
@@ -8,6 +8,11 @@
 			"enabled": true
 		},
 		{
+			"key": "dxAuthBasePath",
+			"value": "auth/v1",
+			"enabled": true
+		},
+		{
 			"key": "openResourceToken",
 			"value": "",
 			"enabled": true

--- a/src/test/resources/README.md
+++ b/src/test/resources/README.md
@@ -1,8 +1,8 @@
 ### Making configurable base path
 - Base path can be added in postman environment file or in postman.
-- `IUDX-Resource-Proxy-Server-Consumer-APIs.postman_environment.postman_environment.json` has **values** array which has a fields named **basePath** whose **value** is currently set to `ngsi-ld/v1`.
+- `IUDX-Resource-Proxy-Server-Consumer-APIs.postman_environment.postman_environment.json` has **values** array which has fields named **basePath** whose **value** is currently set to `ngsi-ld/v1`, **dxAuthBasePath** with value `auth/v1`.
 - The **value** could be changed according to the deployment and then the collection with the `IUDX-Resource-Proxy-Server-Consumer-APIs.postman_environment.postman_environment.json` file can be uploaded to Postman
-- For the changing the **basePath** value in postman after importing the collection and environment files, locate `Resource Proxy Environment` from **Environments** in sidebar of Postman application.
+- For the changing the **basePath**, **dxAuthBasePath** value in postman after importing the collection and environment files, locate `Resource Proxy Environment` from **Environments** in sidebar of Postman application.
 - To know more about Postman environments, refer : [postman environments](https://learning.postman.com/docs/sending-requests/managing-environments/)
 - The **CURRENT VALUE** of the variable could be changed
 


### PR DESCRIPTION
- Referencing datakaveri/iudx-resource-server#368
- Made Catalogue Server base path `iudx/cat/v1`, AAA Server base path `auth/v1` configurable by [updating the files](https://github.com/datakaveri/iudx-rs-proxy/pull/47/commits/bfc735d212e339fb8596fcbc6620c52d024aaa8f). 
- - Changes made in config-dev : 
```
	  	"commonConfig" :  {
		"dxApiBasePath" : "/ngsi-ld/v1",
		"dxCatalogueBasePath": "/iudx/cat/v1",
		"dxAuthBasePath": "/auth/v1"
	   },
```
- Changes made in Postman environment file : 
```
              {
		"key": "dxAuthBasePath",
		"value": "auth/v1",
		"enabled": true
	     },
```